### PR TITLE
chore: Upgrade to PHP 8.5

### DIFF
--- a/app/serverless.yml
+++ b/app/serverless.yml
@@ -25,7 +25,7 @@ functions:
     # This function runs the Laravel website/API
     api:
         handler: public/index.php
-        runtime: php-83-fpm
+        runtime: php-85-fpm
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
         events:
             - httpApi:
@@ -35,7 +35,7 @@ functions:
     # This function lets us run artisan commands in Lambda
     artisan:
         handler: artisan
-        runtime: php-83-console
+        runtime: php-85-console
         timeout: 720 # in seconds
         # Uncomment to also run the scheduler every minute
         #events:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.14-fpm-alpine3.22
+FROM php:8.5-fpm-alpine
 
 RUN apk update && \
     apk add --no-cache bash icu-dev mysql-client autoconf gcc g++ make linux-headers libpng libjpeg libpng-dev libjpeg-turbo-dev libzip-dev && \


### PR DESCRIPTION
PHP 8.5にアップグレードしました。

## 変更内容
- Dockerイメージを `php:8.5-fpm-alpine` に更新
- Brefランタイムを `php-85-fpm` と `php-85-console` に更新

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)